### PR TITLE
*: fix min timestamp

### DIFF
--- a/util/rand.go
+++ b/util/rand.go
@@ -44,7 +44,7 @@ func RdFloat64() float64 {
 
 // RdDate rand date
 func RdDate() time.Time {
-	min := time.Date(1970, 1, 0, 0, 0, 1, 0, time.UTC).Unix()
+	min := time.Date(1970, 1, 1, 0, 0, 1, 0, time.UTC).Unix()
 	max := time.Date(2100, 1, 0, 0, 0, 0, 0, time.UTC).Unix()
 	delta := max - min
 
@@ -55,7 +55,7 @@ func RdDate() time.Time {
 // RdTimestamp return same format as RdDate except rand range
 // TIMESTAMP has a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07'
 func RdTimestamp() time.Time {
-	min := time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).Unix()
+	min := time.Date(1970, 1, 1, 0, 0, 1, 0, time.UTC).Unix()
 	max := time.Date(2038, 1, 19, 3, 14, 7, 0, time.UTC).Unix()
 	delta := max - min
 


### PR DESCRIPTION
previously:

```go
package main

import (
	"fmt"
	"time"
)

func main() {
	ts := time.Date(1970, 1, 0, 0, 0, 0, 0, time.UTC).Unix()
	fmt.Println("ts", ts)

	t := time.Unix(ts, 0).UTC()
	fmt.Println("t", t)
}
```

```
ts -86400
t 1969-12-31 00:00:00 +0000 UT
```